### PR TITLE
fix: update get method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1769,7 +1769,7 @@ dependencies = [
 
 [[package]]
 name = "pubkycore"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "base64",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubkycore"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This PR:
- Fixes `get` function to handle HTTP errors and binary data properly.
- Bumps version to `0.1.6`.